### PR TITLE
Fix typos

### DIFF
--- a/src/main/java/org/LatencyUtils/LatencyStats.java
+++ b/src/main/java/org/LatencyUtils/LatencyStats.java
@@ -152,7 +152,7 @@ public class LatencyStats {
         if (pauseDetector == null) {
             if (defaultPauseDetector == null) {
                 // There is no pause detector supplied, and no default set. Set the default to a default
-                // simple pause detector instance. [User feedback seems to be that this is preferrable to
+                // simple pause detector instance. [User feedback seems to be that this is preferable to
                 // throwing an exception and forcing people to set the default themselves...]
                 synchronized (LatencyStats.class) {
                     if (defaultPauseDetector == null) {
@@ -247,7 +247,7 @@ public class LatencyStats {
      * Add the values value counts accumulated since the last interval histogram was taken
      * into {@code toHistogram}.
      *
-     * Calling {@link #getIntervalHistogramInto}() will reset
+     * Calling {@link #addIntervalHistogramTo}() will reset
      * the interval value counts, and start accumulating value counts for the next interval.
      *
      * @param toHistogram the histogram into which the interval histogram's data should be added

--- a/src/main/java/org/LatencyUtils/SimplePauseDetector.java
+++ b/src/main/java/org/LatencyUtils/SimplePauseDetector.java
@@ -26,7 +26,7 @@ public class SimplePauseDetector extends PauseDetector {
     private final long pauseNotificationThreshold;
     final AtomicLong consensusLatestTime = new AtomicLong();
 
-    private volatile long stallTheadMask = 0;
+    private volatile long stallThreadMask = 0;
     private volatile long stopThreadMask = 0;
 
     private final SimplePauseDetectorThread detectors[];
@@ -117,7 +117,7 @@ public class SimplePauseDetector extends PauseDetector {
                 }
 
                 // This is ***TEST FUNCTIONALITY***: Spin as long as we are externally asked to stall:
-                while ((stallTheadMask & threadMask) != 0);
+                while ((stallThreadMask & threadMask) != 0);
 
                 observedLasUpdateTime = consensusLatestTime.get();
                 // Volatile store above makes sure new "now" is measured after observedLasUpdateTime sample
@@ -167,8 +167,8 @@ public class SimplePauseDetector extends PauseDetector {
      * @throws InterruptedException if internal sleep implementation throws it
      */
     public void stallDetectorThreads(long threadNumberMask, long stallLength) throws InterruptedException {
-        long savedMask = stallTheadMask;
-        stallTheadMask = threadNumberMask;
+        long savedMask = stallThreadMask;
+        stallThreadMask = threadNumberMask;
 
         long startTime = TimeServices.nanoTime();
         long endTime = startTime + stallLength;
@@ -180,7 +180,7 @@ public class SimplePauseDetector extends PauseDetector {
             TimeUnit.NANOSECONDS.sleep(50000); // give things a chance to propagate.
         }
 
-        stallTheadMask = savedMask;
+        stallThreadMask = savedMask;
     }
 
     /**

--- a/src/main/java/org/LatencyUtils/package-info.java
+++ b/src/main/java/org/LatencyUtils/package-info.java
@@ -50,7 +50,7 @@
  * <li>When a pause occurs outside of the tracked operation (and outside of the tracked time window) no long
  * latency value would be recorded, even though any requested operation would be stalled by the pause.</li>
  * </ul>
- * <p>
+ * 
  * <h3>The Solution</h3>
  * The {@link org.LatencyUtils.LatencyStats} class is designed for simple, drop-in use as a latency behavior
  * recording object in common in-process latency recording and tracking situations. LatencyStats includes

--- a/src/test/java/org/LatencyUtils/MovingAverageIntervalEstimatorTest.java
+++ b/src/test/java/org/LatencyUtils/MovingAverageIntervalEstimatorTest.java
@@ -8,9 +8,6 @@ package org.LatencyUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.ref.WeakReference;
-
-
 /**
  * JUnit test for {@link org.LatencyUtils.MovingAverageIntervalEstimatorTest}
  */

--- a/src/test/java/org/LatencyUtils/SimplePauseDetectorTest.java
+++ b/src/test/java/org/LatencyUtils/SimplePauseDetectorTest.java
@@ -6,7 +6,6 @@
 package org.LatencyUtils;
 
 import org.junit.*;
-import java.io.*;
 import java.lang.ref.WeakReference;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;

--- a/src/test/java/org/LatencyUtils/TimeCappedMovingAverageIntervalEstimatorTest.java
+++ b/src/test/java/org/LatencyUtils/TimeCappedMovingAverageIntervalEstimatorTest.java
@@ -8,7 +8,6 @@ package org.LatencyUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.ref.WeakReference;
 import java.util.concurrent.TimeUnit;
 
 


### PR DESCRIPTION
Fix a few typos and remove some leftover imports that I noticed while learning the codebase.

Also, nix a p tag that javadoc didn't like. I checked the output afterwards and it still looks ok to my eyes.