### PR TITLE
Mark PauseDetector constructor protected

### DIFF
--- a/src/main/java/org/LatencyUtils/PauseDetector.java
+++ b/src/main/java/org/LatencyUtils/PauseDetector.java
@@ -22,7 +22,7 @@ public abstract class PauseDetector {
 
     private volatile boolean stop;
 
-    PauseDetector() {
+    protected PauseDetector() {
         pauseDetectorThread.setDaemon(true);
         stop = false;
         pauseDetectorThread.start();


### PR DESCRIPTION
Seems like this was probably intended to allow external implementations.