### PR TITLE
add license file to jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,15 @@
     </distributionManagement>
 
     <build>
+        <resources>
+            <resource>
+                <directory>.</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>LICENSE</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the copyright and licence information from our dependencies. This scanner can extract all informaton from the Jar File. Therefore it would be great to have the license information included in the Jar File.